### PR TITLE
Feature/change mysql to postgres

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,19 +6,13 @@ generator client {
 }
 
 datasource db {
-    provider     = "mysql"
-    relationMode = "prisma"
+    provider     = "postgresql"
+    relationMode = "foreignKeys"
     // NOTE: When using mysql or sqlserver, uncomment the @db.Text annotations in model Account below
     // Further reading:
     // https://next-auth.js.org/adapters/prisma#create-the-prisma-schema
     // https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#string
     url          = env("DATABASE_URL")
-}
-
-model Example {
-    id        String   @id @default(cuid())
-    createdAt DateTime @default(now())
-    updatedAt DateTime @updatedAt
 }
 
 // Necessary for Next auth


### PR DESCRIPTION
### Description
- Updated the datasource provider in the schema.prisma file from "mysql" to "postgresql" and changed the relationMode from "prisma" to "foreignKeys".

### Changes
- Changed the provider value from "mysql" to "postgresql" in the datasource configuration.
- Updated the relationMode from "prisma" to "foreignKeys" in the datasource configuration.

### Testing
- Tested the application with the new datasource provider and relation mode to ensure that the functionality remains intact.